### PR TITLE
Code tweaks and lookup lastAnswerIndex

### DIFF
--- a/3.0/frontend/src/Survey.tsx
+++ b/3.0/frontend/src/Survey.tsx
@@ -48,8 +48,8 @@ export function Survey() {
 
       if (previousQuestions.length === 1) {
         if (Some(sessionId)) {
-          const sid = await surveyClient.getSurveyIdFromZip(sessionId, previousQuestions[0].answer[0]);
-          setSurveyId(sid);
+          const surveyId = await surveyClient.getSurveyIdFromZip(sessionId, previousQuestions[0].answer[0]);
+          setSurveyId(surveyId);
 
           const question = await surveyClient.getSecondQuestion(
             previousQuestions.length,

--- a/3.0/frontend/src/Survey.tsx
+++ b/3.0/frontend/src/Survey.tsx
@@ -47,10 +47,19 @@ export function Survey() {
       }
 
       if (previousQuestions.length === 1) {
-        const sid = await surveyClient.getSurveyIdFromZip(sessionId, previousQuestions[0].answer[0]);
-        setSurveyId(sid);
-        const question = await surveyClient.getSecondQuestion(previousQuestions.length, previousQuestions[0].answer[0]);
-        setCurrentQuestion(question);
+        if (Some(sessionId)) {
+          const sid = await surveyClient.getSurveyIdFromZip(sessionId, previousQuestions[0].answer[0]);
+          setSurveyId(sid);
+
+          const question = await surveyClient.getSecondQuestion(
+            previousQuestions.length,
+            previousQuestions[0].answer[0]
+          );
+
+          setCurrentQuestion(question);
+        } else {
+          throw new Error("Somehow attempting to getSurveyIdFromZip but sessionId is null");
+        }
       }
 
       if (previousQuestions.length > 1) {

--- a/3.0/frontend/src/Survey.tsx
+++ b/3.0/frontend/src/Survey.tsx
@@ -101,7 +101,8 @@ export function Survey() {
     };
 
     getNextQuestion();
-  }, [previousQuestions, previousQuestions.length, sessionId, surveyId]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [previousQuestions.length]);
 
   return (
     <>

--- a/3.0/frontend/src/Survey.tsx
+++ b/3.0/frontend/src/Survey.tsx
@@ -63,13 +63,31 @@ export function Survey() {
       }
 
       if (previousQuestions.length > 1) {
+        const { question: lastQuestion, answer: lastAnswer } = previousQuestions[previousQuestions.length - 1];
+
+        // All other questions need us to pass a `lastAnswerIndex`. In the case of free text strings, this is expected to be 0
+        const getLastAnswerIndex = () => {
+          switch (lastQuestion.type) {
+            case "text_box":
+              return 0;
+
+            case "drop_down":
+            case "radio_button":
+              // TODO: this method searches the possible answer[] provided by backend, and looks for the first result
+              // This is because a drop_down (Select) can only ever pick 1 result
+              // How will we deal with checkboxes, where multiple indices could be selected? Let's deal with that when we get to it!
+              return lastQuestion.answer.findIndex((_) => _ === lastAnswer[0]);
+
+            case "button":
+            case "check_box":
+              throw new Error("Not implemented");
+          }
+        };
+
         const question = await surveyClient.getNextQuestion(
           previousQuestions.length,
           surveyId,
-
-          // TODO: correctly figure out the index here
-          -1,
-
+          getLastAnswerIndex(),
           previousQuestions[previousQuestions.length - 1].answer[0]
         );
         setCurrentQuestion(question);

--- a/3.0/frontend/src/Survey.tsx
+++ b/3.0/frontend/src/Survey.tsx
@@ -66,7 +66,10 @@ export function Survey() {
         const question = await surveyClient.getNextQuestion(
           previousQuestions.length,
           surveyId,
-          previousQuestions[previousQuestions.length - 1].answer[0],
+
+          // TODO: correctly figure out the index here
+          -1,
+
           previousQuestions[previousQuestions.length - 1].answer[0]
         );
         setCurrentQuestion(question);

--- a/3.0/frontend/src/client/surveyClient.ts
+++ b/3.0/frontend/src/client/surveyClient.ts
@@ -64,11 +64,11 @@ const makeSurveyClient = () => {
   };
 
   // TODO: Fix the params of this const
-  const getNextQuestion = async (questionNumber: any, sid: any, lai: any, lain: string) => {
+  const getNextQuestion = async (questionNumber: number, sid: number, lai: number, lain: string) => {
     const queryParams = new URLSearchParams({
-      surveyId: sid,
-      lastQuestionId: questionNumber,
-      lastAnswerIndex: lai,
+      surveyId: sid.toString(),
+      lastQuestionId: questionNumber.toString(),
+      lastAnswerIndex: lai.toString(),
       lastAnswerInput: lain,
     });
 

--- a/3.0/frontend/src/client/surveyClient.ts
+++ b/3.0/frontend/src/client/surveyClient.ts
@@ -39,10 +39,10 @@ const makeSurveyClient = () => {
     return firstQuestion;
   };
 
-  const getSurveyIdFromZip = async (session: string, zipcode: string) => {
+  const getSurveyIdFromZip = async (sessionId: string, zip: string) => {
     const queryParams = new URLSearchParams({
-      sessionId: session,
-      zip: zipcode,
+      sessionId,
+      zip,
     });
 
     const { data: getSurveyIdFromZip } = await httpClient.get<number>(`sessions/getSurveyIdFromZip?${queryParams}`);

--- a/3.0/frontend/src/client/surveyClient.ts
+++ b/3.0/frontend/src/client/surveyClient.ts
@@ -39,7 +39,7 @@ const makeSurveyClient = () => {
     return firstQuestion;
   };
 
-  const getSurveyIdFromZip = async (session: any, zipcode: any) => {
+  const getSurveyIdFromZip = async (session: string, zipcode: string) => {
     const queryParams = new URLSearchParams({
       sessionId: session,
       zip: zipcode,

--- a/3.0/frontend/src/client/surveyClient.ts
+++ b/3.0/frontend/src/client/surveyClient.ts
@@ -50,10 +50,10 @@ const makeSurveyClient = () => {
     return getSurveyIdFromZip;
   };
 
-  const getSecondQuestion = async (questionNumber: any, zipcode: any) => {
+  const getSecondQuestion = async (questionNumber: number, zipcode: string) => {
     const queryParams = new URLSearchParams({
       surveyId: "-1",
-      lastQuestionId: questionNumber,
+      lastQuestionId: questionNumber.toString(),
       lastAnswerIndex: "0",
       lastAnswerInput: zipcode,
     });

--- a/3.0/frontend/src/client/surveyClient.ts
+++ b/3.0/frontend/src/client/surveyClient.ts
@@ -45,9 +45,9 @@ const makeSurveyClient = () => {
       zip,
     });
 
-    const { data: getSurveyIdFromZip } = await httpClient.get<number>(`sessions/getSurveyIdFromZip?${queryParams}`);
+    const { data: surveyId } = await httpClient.get<number>(`sessions/getSurveyIdFromZip?${queryParams}`);
 
-    return getSurveyIdFromZip;
+    return surveyId;
   };
 
   const getSecondQuestion = async (questionNumber: number, zipcode: string) => {

--- a/3.0/frontend/src/client/surveyClient.ts
+++ b/3.0/frontend/src/client/surveyClient.ts
@@ -64,12 +64,17 @@ const makeSurveyClient = () => {
   };
 
   // TODO: Fix the params of this const
-  const getNextQuestion = async (questionNumber: number, sid: number, lai: number, lain: string) => {
+  const getNextQuestion = async (
+    questionNumber: number,
+    surveyId: number,
+    lastAnswerIndex: number,
+    lastAnswerInput: string
+  ) => {
     const queryParams = new URLSearchParams({
-      surveyId: sid.toString(),
+      surveyId: surveyId.toString(),
       lastQuestionId: questionNumber.toString(),
-      lastAnswerIndex: lai.toString(),
-      lastAnswerInput: lain,
+      lastAnswerIndex: lastAnswerIndex.toString(),
+      lastAnswerInput,
     });
 
     const { data: nextQuestion } = await httpClient.get<Question>(`questions/getNextQuestion?${queryParams}`);

--- a/3.0/frontend/src/client/surveyClient.ts
+++ b/3.0/frontend/src/client/surveyClient.ts
@@ -50,12 +50,12 @@ const makeSurveyClient = () => {
     return surveyId;
   };
 
-  const getSecondQuestion = async (questionNumber: number, zipcode: string) => {
+  const getSecondQuestion = async (questionNumber: number, zip: string) => {
     const queryParams = new URLSearchParams({
       surveyId: "-1",
       lastQuestionId: questionNumber.toString(),
       lastAnswerIndex: "0",
-      lastAnswerInput: zipcode,
+      lastAnswerInput: zip,
     });
 
     const { data: secondQuestion } = await httpClient.get<Question>(`questions/getNextQuestion?${queryParams}`);

--- a/3.0/frontend/src/components/QuestionCard.tsx
+++ b/3.0/frontend/src/components/QuestionCard.tsx
@@ -1,6 +1,6 @@
 import { Button, Card, Col, Input, Select, Row, Typography, Radio } from "antd";
 import { useState } from "react";
-import { AnswerWithIndex, Question } from "../types";
+import { Question } from "../types";
 import { Some } from "../utils/Some";
 
 type Props = {
@@ -12,7 +12,7 @@ type Props = {
 };
 
 export const QuestionCard = ({ question, onNext }: Props) => {
-  const [answer, setAnswer] = useState<AnswerWithIndex>();
+  const [answer, setAnswer] = useState<string[]>([]);
   const [validationError, setValidationError] = useState<string>();
   console.log(question);
 
@@ -23,22 +23,20 @@ export const QuestionCard = ({ question, onNext }: Props) => {
       <Row className="mb1">
         <Col span={24}>
           {/* TODO: support all question.types possible */}
-          {/* {question.type === "text_box" && (
-            <Input value={answer} onChange={(e) => setAnswer({e.target.index, e.target.value})} />
-          )}
-          {question.type === "radio_button" && <Radio value={answer} onChange={(e) => setAnswer({e.target.index, e.target.value})} />}
+          {question.type === "text_box" && <Input value={answer} onChange={(e) => setAnswer([e.target.value])} />}
+          {question.type === "radio_button" && <Radio value={answer} onChange={(e) => setAnswer([e.target.value])} />}
 
           {question.type === "drop_down" && (
-            <Select style={{ width: "100%" }} onChange={(answer: string) => setAnswer({answer.answerIndex, answer.answerValue})}>
+            <Select style={{ width: "100%" }} onChange={(answer: string) => setAnswer([answer])}>
               {question.answer
                 .filter((answer) => answer !== "")
                 .map((answer) => (
-                  <Select.Option key={answer} value={{answer.answerIndex, answer.answerValue}}>
+                  <Select.Option key={answer} value={answer}>
                     {answer}
                   </Select.Option>
                 ))}
             </Select>
-          )} */}
+          )}
 
           {/* Handle "Checkbox" by using Antd Checkbox.Group */}
 
@@ -50,13 +48,13 @@ export const QuestionCard = ({ question, onNext }: Props) => {
         type="primary"
         onClick={() => {
           // TODO: how can we do better validation (like zipCode) at this step?
-          if (answer?.answerText === "") {
+          if (answer.length === 0 || answer[0] === "") {
             setValidationError("Please enter a valid answer");
           } else {
             // If validation passes, we tell the parent component what the answer is
             // Parent component will pop the answer into previousQuestions, and then ask the API for the next question
             // And maybe some other stuff too
-            onNext(["71018"]);
+            onNext(answer);
           }
         }}
       >

--- a/3.0/frontend/src/components/QuestionCard.tsx
+++ b/3.0/frontend/src/components/QuestionCard.tsx
@@ -23,7 +23,7 @@ export const QuestionCard = ({ question, onNext }: Props) => {
       <Row className="mb1">
         <Col span={24}>
           {/* TODO: support all question.types possible */}
-          {question.type === "text_box" && (
+          {/* {question.type === "text_box" && (
             <Input value={answer} onChange={(e) => setAnswer({e.target.index, e.target.value})} />
           )}
           {question.type === "radio_button" && <Radio value={answer} onChange={(e) => setAnswer({e.target.index, e.target.value})} />}
@@ -38,7 +38,7 @@ export const QuestionCard = ({ question, onNext }: Props) => {
                   </Select.Option>
                 ))}
             </Select>
-          )}
+          )} */}
 
           {/* Handle "Checkbox" by using Antd Checkbox.Group */}
 
@@ -56,7 +56,7 @@ export const QuestionCard = ({ question, onNext }: Props) => {
             // If validation passes, we tell the parent component what the answer is
             // Parent component will pop the answer into previousQuestions, and then ask the API for the next question
             // And maybe some other stuff too
-            onNext(answer);
+            onNext(["71018"]);
           }
         }}
       >

--- a/3.0/frontend/src/types.ts
+++ b/3.0/frontend/src/types.ts
@@ -13,8 +13,3 @@ export type QuestionAndAnswer = {
   question: Question;
   answer: string[];
 };
-
-export type AnswerWithIndex = {
-  answerIndex: string;
-  answerText: string;
-};


### PR DESCRIPTION
- Comment and hardcode to get software running
- Use strong types in surveyClient.getSurveyIdFromZip
- Use strong types in surveyClient.getSecondQuestion
- Use strong types in surveyClient.getNextQuestion
- Don't rename variables when using getSurveyIdFromZip
- Use better variable naming in surveyClient.getSurveyIdFromZip
- Use consistent variable naming for zip
- Avoid shortening variable names in Survey
- Avoid shortening and renaming variables in surveyClient.getNextQuestion
- Remove AnswerWithIndex concept
- Lookup and pass lastAnswerIndex for drop_down/radio_button
- Force useEffect dependency array to only watch previousQuestions.length
